### PR TITLE
fix: limit the amount of created connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a part of the [**Sofie** TV News Studio Automation System](https://githu
 
 ## Abstract
 
-A client-side library for the [Sofie Quantel Gateway](https://github.com/nrkno/tv-automation-quantel-gateway).
+A client-side library for the [Sofie Quantel Gateway](https://github.com/nrkno/sofie-quantel-gateway).
 
 ## Usage
 
@@ -51,7 +51,7 @@ Once finished with the class, call `dispose()`.
 ### Documentation
 
 The library is self-documenting using TypeDoc annotations. Details of the REST API
-that this library is a client for can be found in the [Quantel Gateway documentation](https://github.com/nrkno/tv-automation-quantel-gateway#http-api).
+that this library is a client for can be found in the [Quantel Gateway documentation](https://github.com/nrkno/sofie-quantel-gateway#http-api).
 
 ## License
 

--- a/src/quantelGateway.ts
+++ b/src/quantelGateway.ts
@@ -1,14 +1,37 @@
 import * as Q from './quantelTypes'
 import * as got from 'got'
+import { Agent as HTTPAgent } from 'http'
+import { Agent as HTTPSAgent } from 'https'
 import { EventEmitter } from 'events'
 
 const CHECK_STATUS_INTERVAL = 3000
 const CALL_TIMEOUT = 1000
 
+const MAX_FREE_SOCKETS = 5
+const MAX_SOCKETS_PER_HOST = 1
+const MAX_ALL_SOCKETS = 10
+const HTTP_TIMEOUT = 5000
+
+const gatewayHTTPAgent = new HTTPAgent({
+	keepAlive: true,
+	maxFreeSockets: MAX_FREE_SOCKETS,
+	maxSockets: MAX_SOCKETS_PER_HOST,
+	maxTotalSockets: MAX_ALL_SOCKETS,
+	timeout: HTTP_TIMEOUT,
+})
+
+const gatewayHTTPSAgent = new HTTPSAgent({
+	keepAlive: true,
+	maxFreeSockets: MAX_FREE_SOCKETS,
+	maxSockets: MAX_SOCKETS_PER_HOST,
+	maxTotalSockets: MAX_ALL_SOCKETS,
+	timeout: HTTP_TIMEOUT,
+})
+
 const literal = <T>(t: T): T => t
 
 /**
- * Remote connection to a [Sofie Quantel Gateway](https://github.com/nrkno/tv-automation-quantel-gateway).
+ * Remote connection to a [Sofie Quantel Gateway](https://github.com/nrkno/sofie-quantel-gateway).
  * Create and initialize a new connection as follows:
  *
  *     const quantelClient = new QuantelGateway()
@@ -616,6 +639,12 @@ export class QuantelGateway extends EventEmitter {
 				timeout: CALL_TIMEOUT,
 				responseType: 'json',
 				resolveBodyOnly: false,
+				// explicitly disable HTTP/2, because it's not tested
+				http2: false,
+				agent: {
+					http: gatewayHTTPAgent,
+					https: gatewayHTTPSAgent,
+				},
 			})
 			if (response.statusCode === 200) {
 				return response.body

--- a/src/quantelGateway.ts
+++ b/src/quantelGateway.ts
@@ -8,8 +8,8 @@ const CHECK_STATUS_INTERVAL = 3000
 const CALL_TIMEOUT = 1000
 
 const MAX_FREE_SOCKETS = 5
-const MAX_SOCKETS_PER_HOST = 1
-const MAX_ALL_SOCKETS = 10
+const MAX_SOCKETS_PER_HOST = 5
+const MAX_ALL_SOCKETS = 25
 const HTTP_TIMEOUT = 5000
 
 const gatewayHTTPAgent = new HTTPAgent({


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

- **What is the current behavior?** (You can also link to an open issue here)

The default NodeJS HTTP Agent will create as many connections as possible and keep it alive for a long time. This can cause problems when there's large spikes of requests that need to be made to the Quantel Gateway.

- **What is the new behavior (if this is a feature change)?**

The amount of concurrent connection is limited for the entire module to avoid a resource exhaustion scenario.

- **Other information**:
